### PR TITLE
Generate an activate script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,18 @@ This will download the sources of everything into
 `<directory name>/win32-dev` and extract the current Pidgin release into
 `<directory name>/pidgin-<version>`.
 
-When it has completed you can then "activate" the build directory by running
+When it has completed you can then "activate" the dev environment by sourcing
+the activation script in the win32-dev directory.
+
+```sh
+source <directory name>/win32-dev/activate
+```
+
+You can also deactivate it by typing `deactivate`.
+
+Previously, activation was done by running the following command. This still
+works, but has been deprecated in favor of the `activate` script and will be
+removed in a future version.
 
 ```sh
 eval $(./pidgin-windev.sh <directory name> --path)

--- a/pidgin-windev.sh
+++ b/pidgin-windev.sh
@@ -5,6 +5,9 @@ pidgin_version="2.14.13"
 devroot="$1"
 path="$2"
 
+SCRIPT_RELATIVE_PATH=$(dirname "${0}")
+SCRIPT_ABSOLUTE_PATH=$(realpath "${SCRIPT_RELATIVE_PATH}")
+
 if [[ "$1" = -* || -z "$devroot" || ( -n "$path" && "$path" != --path ) ]]; then echo "
     Pidgin Windows Development Setup ${version}
     Target Pidgin version ${pidgin_version}
@@ -135,6 +138,9 @@ install() {
 
 # Path configuration
 if [[ -n "$path" ]]; then
+    echo "--path is deprecated. Source the 'activate' script that is in the win32-dev"
+    echo "directory instead"
+
     printf "%s" "export PATH='"
     printf "%s" "${win32}/${mingw}/bin:"
     printf "%s" "${win32}/${perl_dir}/perl/bin:"
@@ -282,6 +288,9 @@ extract zip    "${win32}/gtk_2_0-2.14"    "${cache}/gtk+-bundle_2.14.7-20090119_
 extract zip    "${win32}/${intltool}"     "${cache}/${intltool}.zip"
 extract gzip   "${win32}/${gcc_core44}"   "${cache}/${gcc_core44}.tar.gz"
 info "Installing" "SHA1 plugin for NSIS"; cp "${win32}/${pidgin_inst_deps}/SHA1Plugin.dll" "${win32}/${nsis}/Plugins"
+info "Installing" "activation script"
+# shellcheck disable=SC2016
+MINGW=${mingw} NSIS=${nsis} PERL=${perl} envsubst '$MINGW $NSIS $PERL' < "${SCRIPT_ABSOLUTE_PATH}/templates/activate.in" > "${win32}/activate"
 echo
 
 # Finishing

--- a/templates/activate.in
+++ b/templates/activate.in
@@ -1,0 +1,57 @@
+# shellcheck shell=bash
+# This script is heavily based off of `bin/activate` from python virtualenv.
+# It must be sourced by bash with `source <devenv>/activate`
+
+if [ "${BASH_SOURCE-}" = "$0" ]; then
+    echo "You must source this script: \$ source $0" >&2
+    exit 1
+fi
+
+RELATIVE_WINDEV=$(dirname "${BASH_SOURCE-}")
+WINDEV=$(realpath "${RELATIVE_WINDEV}")
+
+deactivate() {
+    if [ -n "${_OLD_PIDGIN_WINDEV_PATH:+_}" ] ; then
+        PATH="${_OLD_PIDGIN_WINDEV_PATH}"
+        export PATH
+        unset _OLD_PIDGIN_WINDEV_PATH
+    fi
+
+    # This should detect bash and zsh, which have a hash command that must
+    # be called to get it to forget past commands.  Without forgetting
+    # past commands the $PATH changes we made may not be respected
+    if [ -n "${BASH-}" ] || [ -n "${ZSH_VERSION-}" ] ; then
+        hash -r 2>/dev/null
+    fi
+
+    unset WIN32_DEV_TOP
+    unset PIDGIN_WINDEV
+    if [ ! "${1-}" = "nondestructive" ] ; then
+    # Self destruct!
+        unset -f deactivate
+    fi
+}
+
+deactivate nondestructive
+
+printf "activating pidgin windev '%s'\n" "${WINDEV}"
+
+# Save the path for the virtual environment
+PIDGIN_WINDEV="${WINDEV}"
+export PIDGIN_WINDEV
+
+# Store the old path so it can be restored on deactivation
+_OLD_PIDGIN_WINDEV_PATH="${PATH}"
+PATH="${PIDGIN_WINDEV}/${MINGW}/bin:${PIDGIN_WINDEV}/${PERL}/perl/bin:${PIDGIN_WINDEV}/${NSIS}/:${PATH}"
+export PATH
+
+# Update WIN32_DEV_TOP so that the Pidgin build with automatically find this
+WIN32_DEV_TOP="${WINDEV}"
+export WIN32_DEV_TOP
+
+# This should detect bash and zsh, which have a hash command that must
+# be called to get it to forget past commands.  Without forgetting
+# past commands the $PATH changes we made may not be respected
+if [ -n "${BASH-}" ] || [ -n "${ZSH_VERSION-}" ] ; then
+    hash -r 2>/dev/null
+fi


### PR DESCRIPTION
The generated script gets added to the win32-dev directory so that the entire directory can be distributed and used by other parties.

The activate script works just like the python virtualenv activate script but does not modify the prompt. I was undecided on this so I didn't do it.

The activate script also exports the `WIN32_DEV_TOP` environment variable which `libpurple/win32/global.mak` will use if set which means you can download a pre-build win32-dev directory, activate it, and build pidgin without touching a single Makefile.

Fixes #3